### PR TITLE
Implements the `enforcer` CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Mac OS X files
 .DS_Store
 
+# binary directory
+bin/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 
 .PHONY: build
 build:
-	go build ${LDFLAGS} ${GCFLAGS} -v -o bin/replicated $(BUILDFLAGS) ./cmd/replicated
+	go build ${LDFLAGS} ${GCFLAGS} -v -o bin/enforcer $(BUILDFLAGS) ./cmd/enforcer
 
 .PHONY: fmt
 fmt:
@@ -13,18 +13,6 @@ fmt:
 .PHONY: vet
 vet:
 	go vet $(BUILDFLAGS) ./pkg/... ./cmd/...
-
-.PHONY: build-ttl.sh
-build-ttl.sh:
-	docker buildx build .  -t ttl.sh/${USER}/replicated-sdk:24h -f deploy/Dockerfile
-	docker push ttl.sh/${USER}/replicated-sdk:24h
-
-	make -C chart build-ttl.sh
-
-.PHONY: mock
-mock:
-	go install github.com/golang/mock/mockgen@v1.6.0
-	mockgen -source=pkg/store/store_interface.go -destination=pkg/store/mock/mock_store.go
 
 .PHONY: scan
 scan:

--- a/cmd/enforcer/main.go
+++ b/cmd/enforcer/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+    "os"
+    "fmt"
+    "time"
+    "errors"
+
+    "github.com/crdant/replicated-license-enforcer/pkg/client"
+
+    backoff "github.com/cenkalti/backoff/v4"
+)
+
+func checkLicense(client client.ExpirationClient) error {
+    expiration, err := client.GetExpirationDate()
+    if err != nil {
+        return err
+    }
+
+    if expiration.Before(time.Now()) {
+        return errors.New("License is expired")
+    }
+
+    return nil
+}
+
+func main() {
+    endpoint := os.Getenv("REPLICATED_SDK_ENDPOINT")
+    sdkClient := client.NewClient(endpoint)
+
+    check := func() error {
+      err := checkLicense(sdkClient)
+      if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        return err
+      }
+      return nil
+    }
+
+    err := backoff.Retry(check, backoff.NewExponentialBackOff())
+    if err != nil {
+
+        os.Exit(1) 
+    }
+
+    fmt.Fprintln(os.Stdout, "License is valid.")
+    os.Exit(0)
+}

--- a/cmd/enforcer/main_test.go
+++ b/cmd/enforcer/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+    "time"
+    "testing"
+
+    "github.com/stretchr/testify/mock"
+)
+
+type MockAPIClient struct {
+    mock.Mock
+}
+
+func (m *MockAPIClient) GetExpirationDate() (time.Time, error) {
+    args := m.Called()
+    return args.Get(0).(time.Time), args.Error(1)
+}
+
+func TestLicenseCheckValidLicense(t *testing.T) {
+    future := time.Now().Add(24 * time.Hour)
+    mockClient := new(MockAPIClient)
+    mockClient.On("GetExpirationDate", mock.Anything).Return(future, nil)
+
+    err := checkLicense(mockClient)
+    if err != nil {
+        t.Fatalf("Expected license to be valid and got %v", err)
+    }
+}
+
+
+func TestLicenseCheckExpriredLicense(t *testing.T) {
+    future := time.Now().Add(-24 * time.Hour)
+    mockClient := new(MockAPIClient)
+    mockClient.On("GetExpirationDate", mock.Anything).Return(future, nil)
+
+    err := checkLicense(mockClient)
+    if err == nil {
+        t.Fatalf("Expected license to be invalid and got %v", err)
+    }
+}
+

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,18 @@
-module github.com/crdant/replicated-sdk-client
+module github.com/crdant/replicated-license-enforcer
 
 go 1.22.0
 
 toolchain go1.22.3
 
-require github.com/replicatedhq/replicated-sdk v1.0.0-beta.20
+require (
+	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/replicatedhq/replicated-sdk v1.0.0-beta.20
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,16 @@
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/replicatedhq/replicated-sdk v1.0.0-beta.20 h1:6Md+n9mgnkpv97pB12Yo6hn9ndyyR0mQb3jbEhPrf9E=
 github.com/replicatedhq/replicated-sdk v1.0.0-beta.20/go.mod h1:ymfOVZfLvTuXIVUmMj0J6b+5yJYAcG0XOypOpHyFceo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/client/license.go
+++ b/pkg/client/license.go
@@ -9,8 +9,13 @@ import (
     "crypto/x509"
     "encoding/base64"
     "encoding/pem"
+
     license "github.com/replicatedhq/replicated-sdk/pkg/license/types"
 )
+
+type ExpirationClient interface {
+  GetExpirationDate() (time.Time, error) 
+}
 
 // Return the expiration date for the license as a date field since it's
 // a special case of the fields in the license


### PR DESCRIPTION
TL;DR
-----

Provides a simple CLI to check if the license is expired

Details
-------

Adds the command `enforcer` that will exit non-zero for an expired
license and zero if the license is valid.  The command doesn't take any
arguments and locates the SDK using the environment variable
`REPLICATED_SDK_ENDPOINT`. It uses exponential backoff to avoid DDOSing
the `repllicated.app` endpoint (or your CNAME thereof).
