### PR TITLE
Adds CI/CD for CLI and Docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,29 +4,29 @@ on:
   - push
   - pull_request
   - workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch
-        required: true
-        default: main
-        type: string
-      namespace:
-        description: Registry Namespace
-        required: true
-        type: string
-      slug:
-        description: Replicated App Slug
-        required: true
-        type: string
-      version:
-        description: Release Version
-        required: true
-        type: string
-      proxy:
-        description: Proxy Image Registry
-        required: true
-        default: proxy.replicated.com
-        type: string
+      inputs:
+        branch:
+          description: Branch
+          required: true
+          default: main
+          type: string
+        namespace:
+          description: Registry Namespace
+          required: true
+          type: string
+        slug:
+          description: Replicated App Slug
+          required: true
+          type: string
+        version:
+          description: Release Version
+          required: true
+          type: string
+        proxy:
+          description: Proxy Image Registry
+          required: true
+          default: proxy.replicated.com
+          type: string
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,30 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch
-        required: true
-        default: main
-        type: string
-      namespace:
-        description: Registry Namespace
-        required: true
-        type: string
-      slug:
-        description: Replicated App Slug
-        required: true
-        type: string
-      version:
-        description: Release Version
-        required: true
-        type: string
-      proxy:
-        description: Proxy Image Registry
-        required: true
-        default: proxy.replicated.com
-        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -77,7 +53,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for web image
+      - name: Extract metadata (tags, labels) for image image
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -88,7 +64,7 @@ jobs:
                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
-          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/replicated-license-enforcer
 
       - uses: int128/docker-build-cache-config-action@v1
         id: cache
@@ -131,6 +107,6 @@ jobs:
       - name: Sign the image
         id: sign-image
         run: |
-          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build-image.outputs.digest }} --yes
-          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
+          cosign sign ${{ env.REGISTRY }}/${{ github.repository_owner }}/slackernews-web@${{ needs.build-image.outputs.digest }} --yes
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ github.repository_owner }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,8 @@ jobs:
 
   build-image:
     runs-on: ubuntu-22.04
+    needs:
+      - build-and-test
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,32 +1,32 @@
 name: CI
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch:
-      inputs:
-        branch:
-          description: Branch
-          required: true
-          default: main
-          type: string
-        namespace:
-          description: Registry Namespace
-          required: true
-          type: string
-        slug:
-          description: Replicated App Slug
-          required: true
-          type: string
-        version:
-          description: Release Version
-          required: true
-          type: string
-        proxy:
-          description: Proxy Image Registry
-          required: true
-          default: proxy.replicated.com
-          type: string
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch
+        required: true
+        default: main
+        type: string
+      namespace:
+        description: Registry Namespace
+        required: true
+        type: string
+      slug:
+        description: Replicated App Slug
+        required: true
+        type: string
+      version:
+        description: Release Version
+        required: true
+        type: string
+      proxy:
+        description: Proxy Image Registry
+        required: true
+        default: proxy.replicated.com
+        type: string
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,11 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.16'  # Specify the Go version
+        go-version: '1.22'  # Specify the Go version
 
     - name: Format Code
       run: make fmt
@@ -107,6 +107,6 @@ jobs:
       - name: Sign the image
         id: sign-image
         run: |
-          cosign sign ${{ env.REGISTRY }}/${{ github.repository_owner }}/slackernews-web@${{ needs.build-image.outputs.digest }} --yes
-          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ github.repository_owner }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
+          cosign sign ${{ env.REGISTRY }}/${{ github.repository_owner }}/replicated-license-enforcer@${{ needs.build-image.outputs.digest }} --yes
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ github.repository_owner }}/replicated-license-enforcer@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,134 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+  - workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch
+        required: true
+        default: main
+        type: string
+      namespace:
+        description: Registry Namespace
+        required: true
+        type: string
+      slug:
+        description: Replicated App Slug
+        required: true
+        type: string
+      version:
+        description: Release Version
+        required: true
+        type: string
+      proxy:
+        description: Proxy Image Registry
+        required: true
+        default: proxy.replicated.com
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+ 
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'  # Specify the Go version
+
+    - name: Format Code
+      run: make fmt
+
+    - name: Vet Code
+      run: make vet
+
+    - name: Run Tests
+      run: make test
+
+    - name: Build
+      run: make build
+
+  build-image:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for web image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+                type=sha,format=long
+                type=schedule
+                type=raw,${{ inputs.version }}
+                type=ref,event=branch
+                type=ref,event=tag
+                type=ref,event=pr
+          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web
+
+      - uses: int128/docker-build-cache-config-action@v1
+        id: cache
+        with:
+          image: ghcr.io/${{ github.repository }}/cache
+
+      - name: Build enforcer image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ./deployment/Dockerfile
+          push: true
+          cache-from: ${{ steps.cache.outputs.cache-from }}
+          cache-to: ${{ steps.cache.outputs.cache-to }}
+
+
+  sign-image:
+    runs-on: ubuntu-22.04
+    needs:
+      - build-image
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      signature: ${{ steps.sign-image.outputs.signature }}
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.3.0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign the image
+        id: sign-image
+        run: |
+          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build-image.outputs.digest }} --yes
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and sign image
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	go test -v $(TEST_BUILDFLAGS) ./pkg/... ./cmd/... -coverprofile cover.out
 
 .PHONY: build
-build: vet test
+build: 
 	go build ${LDFLAGS} ${GCFLAGS} -v -o bin/enforcer $(BUILDFLAGS) ./cmd/enforcer
 
 .PHONY: fmt

--- a/Makefile.build.mk
+++ b/Makefile.build.mk
@@ -1,3 +1,6 @@
+export GOPROXY=https://proxy.golang.org
+export CGO_ENABLED=0
+
 SHELL := /bin/bash -o pipefail
 VERSION_PACKAGE = github.com/crdant/replicated-license-enforcer/pkg/version
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),alpha)
@@ -41,3 +44,6 @@ define LDFLAGS
 "
 endef
 endif
+
+BUILDFLAGS = -tags='netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -installsuffix netgo
+TEST_BUILDFLAGS = -tags='testing netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -installsuffix netgo

--- a/Makefile.build.mk
+++ b/Makefile.build.mk
@@ -26,9 +26,9 @@ endif
 ifeq ("$(DEBUG_REPLICATED)", "1")
 define LDFLAGS
 -ldflags "\
-	-X ${VERSION_PACKAGE}.version=${VERSION} \
-	-X ${VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
-	-X ${VERSION_PACKAGE}.buildTime=${DATE} \
+	-X ${VERSION_PACKAGE}.Version=${VERSION} \
+	-X ${VERSION_PACKAGE}.GitSHA=${GIT_SHA} \
+	-X ${VERSION_PACKAGE}.BuildTime=${DATE} \
 "
 endef
 define GCFLAGS
@@ -38,9 +38,9 @@ else
 define LDFLAGS
 -ldflags "\
 	-s -w \
-	-X ${VERSION_PACKAGE}.version=${VERSION} \
-	-X ${VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
-	-X ${VERSION_PACKAGE}.buildTime=${DATE} \
+	-X ${VERSION_PACKAGE}.Version=${VERSION} \
+	-X ${VERSION_PACKAGE}.GitSHA=${GIT_SHA} \
+	-X ${VERSION_PACKAGE}.BuildTime=${DATE} \
 "
 endef
 endif

--- a/cmd/enforcer/main.go
+++ b/cmd/enforcer/main.go
@@ -29,7 +29,7 @@ func main() {
 	endpoint := os.Getenv("REPLICATED_SDK_ENDPOINT")
 	sdkClient := client.NewClient(endpoint)
   
-  fmt.Printf("Version: %s, Build Time: %s, GitCommit: %s", version.Version, version.BuildTime, version.GitSHA)
+  fmt.Printf("Version: %s, Build Time: %s, GitCommit: %s\n", version.Version, version.BuildTime, version.GitSHA)
 
 	check := func() error {
 		err := checkLicense(sdkClient)

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -23,14 +23,13 @@ ENV GIT_TAG=${git_tag}
 
 RUN --mount=type=cache,target=${GOMODCACHE} \
     --mount=type=cache,target=${GOCACHE} \
-    make build && mv ./bin/replicated /replicated
+    make build && mv ./bin/enforcer /enforcer
 
 FROM cgr.dev/chainguard/static:latest
 
-COPY --from=builder /replicated /replicated
+COPY --from=builder /enforcer /enforcer
 
 WORKDIR /
 
 EXPOSE 3000
-ENTRYPOINT ["/replicated"]
-CMD ["api"]
+ENTRYPOINT ["/enforcer"]

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,36 @@
+FROM cgr.dev/chainguard/wolfi-base:latest as local_go
+
+RUN apk update && apk add ca-certificates-bundle build-base openssh go-1.22~=1.22.2
+ENTRYPOINT /usr/bin/go
+
+FROM local_go as builder
+
+ENV GOMODCACHE=/.cache/gomod-cache
+ENV GOCACHE=/.cache/go-cache
+
+ENV PROJECTPATH=/go/src/github.com/crdant/replicated-license-enforcer
+WORKDIR $PROJECTPATH
+
+COPY Makefile.build.mk ./
+COPY Makefile ./
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=${GOMODCACHE} go mod download
+COPY cmd ./cmd
+COPY pkg ./pkg
+
+ARG git_tag
+ENV GIT_TAG=${git_tag}
+
+RUN --mount=type=cache,target=${GOMODCACHE} \
+    --mount=type=cache,target=${GOCACHE} \
+    make build && mv ./bin/replicated /replicated
+
+FROM cgr.dev/chainguard/static:latest
+
+COPY --from=builder /replicated /replicated
+
+WORKDIR /
+
+EXPOSE 3000
+ENTRYPOINT ["/replicated"]
+CMD ["api"]


### PR DESCRIPTION
Creates an initial CI/CD pipeline

TL;DR
-----

Adds a simple CI/CD pipeline for the enforcer image

Details
-------

Uses GitHub actions to build, sign, and publish a container image for the
enforcer. The image is build on all pushes and pull requests.
