### PR TITLE
Enhances to run as a sidecar

### DIFF
--- a/cmd/enforcer/main.go
+++ b/cmd/enforcer/main.go
@@ -108,7 +108,7 @@ func main() {
     }
     go c.Start()
 
-    sig := make(chan os.Signal)
+    sig := make(chan os.Signal, 1)
     signal.Notify(sig, os.Interrupt, os.Kill)
     <-sig
   }

--- a/cmd/enforcer/main.go
+++ b/cmd/enforcer/main.go
@@ -59,7 +59,7 @@ func check() error {
     name, _ := sdkClient.GetAppName()
     slug, _ := sdkClient.GetAppSlug()
 
-    k8sClient.CreateLicenseEvent(valid, slug, expiration)
+    k8sClient.CreateLicenseEvent(slug, expiration)
     if !valid {
       log.Infof("License for %s is expired", name)
       return errors.New(fmt.Sprintf("License for %s is expired", name))
@@ -86,7 +86,11 @@ func recheck() {
 }
 
 func main() {
-  log.SetLevel(log.DebugLevel)
+  logLevel := os.Getenv("LOG_LEVEL")
+  if logLevel == "" {
+    logLevel = "info"
+  }
+  log.ParseLevel(logLevel)
   log.Infof("Version: %s, Build Time: %s, GitCommit: %s\n", version.Version, version.BuildTime, version.GitSHA)
 
   recheckInterval := flag.Duration("recheck", time.Duration(0), "Recheck license periodically to assure it's still valid")

--- a/cmd/enforcer/main.go
+++ b/cmd/enforcer/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"errors"
+  "flag"
 	"fmt"
 	"os"
+  "os/signal"
 	"time"
 
 	"github.com/crdant/replicated-license-enforcer/pkg/client"
@@ -11,6 +13,7 @@ import (
 	"github.com/crdant/replicated-license-enforcer/pkg/version"
 
   "github.com/charmbracelet/log"
+  cron "github.com/robfig/cron/v3"
 	backoff "github.com/cenkalti/backoff/v4"
 )
 
@@ -27,50 +30,87 @@ func checkLicense(client client.ReplicatedClient) (bool, error) {
 	return true, nil
 }
 
+func check() error {
+    endpoint := os.Getenv("REPLICATED_SDK_ENDPOINT")
+    if endpoint == "" {
+      // this is the default in the current build of the SDK
+      endpoint = "http://replicated:3000"
+    } 
+    sdkClient := client.NewClient(endpoint)
+
+    valid, err := checkLicense(sdkClient)
+    if err != nil {
+      log.Error("checking license", "error", err)
+      return err
+    }
+    log.Debug("Fetching license details and creating event")
+
+    k8sClient, err := events.NewKubernetesEventClient()
+    if err != nil {
+      log.Error("Could not create Kuberenetes client", "error", err)
+      return err
+    }
+    expiration, err := sdkClient.GetExpirationDate()
+    if err != nil {
+      log.Error("Error finding expiration date to incldue in kubernetes event", "error", err)
+      return err
+    }
+
+    name, _ := sdkClient.GetAppName()
+    slug, _ := sdkClient.GetAppSlug()
+
+    k8sClient.CreateLicenseEvent(valid, slug, expiration)
+    if !valid {
+      log.Infof("License for %s is expired", name)
+      return errors.New(fmt.Sprintf("License for %s is expired", name))
+    }
+
+    log.Info("License is valid")
+    return nil
+}
+
+func validate() error {
+    err := backoff.Retry(check, backoff.NewExponentialBackOff())
+    if err != nil {
+        log.Error("Error in license check, skipping current check", "error", err)
+        return errors.New("Error in license check")
+    }
+    return nil
+}
+  
+func recheck() { 
+  err := validate()
+  if err != nil {
+      log.Error("Error in license check, skipping current check", "error", err)
+  }
+}
+
 func main() {
   log.SetLevel(log.DebugLevel)
-	endpoint := os.Getenv("REPLICATED_SDK_ENDPOINT")
-	sdkClient := client.NewClient(endpoint)
+  log.Infof("Version: %s, Build Time: %s, GitCommit: %s\n", version.Version, version.BuildTime, version.GitSHA)
+
+  recheckInterval := flag.Duration("recheck", time.Duration(0), "Recheck license periodically to assure it's still valid")
+  flag.Parse()
+
+  err := validate()
+  if err != nil {
+    log.Error("Error checking license validity", "error", err)
+    os.Exit(1)
+  }
   
-  fmt.Printf("Version: %s, Build Time: %s, GitCommit: %s\n", version.Version, version.BuildTime, version.GitSHA)
+  if *recheckInterval != time.Duration(0) {
+    log.Infof("Rechecking license every %v", *recheckInterval)
+    c := cron.New()
+    _, err := c.AddFunc(fmt.Sprintf("@every %v", recheckInterval), recheck)
+    if err != nil {
+      log.Error("Could not schedule periodic license check", "error", err)
+      return
+    }
+    go c.Start()
 
-	check := func() error {
-      valid, err := checkLicense(sdkClient)
-      if err != nil {
-        log.Error("checking license", "error", err)
-        return err
-      }
-      log.Debug("Fetching license details and creating event")
-
-      k8sClient, err := events.NewKubernetesEventClient()
-      if err != nil {
-        log.Error("Could not create Kuberenetes client", "error", err)
-        return err
-      }
-      expiration, err := sdkClient.GetExpirationDate()
-      if err != nil {
-        log.Error("Error finding expiration date to incldue in kubernetes event", "error", err)
-        return err
-      }
-
-      name, _ := sdkClient.GetAppName()
-      slug, _ := sdkClient.GetAppSlug()
-
-      k8sClient.CreateLicenseEvent(valid, slug, expiration)
-      if !valid {
-        log.Infof("License for %s is expired", name)
-        return errors.New(fmt.Sprintf("License for %s is expired", name))
-      }
-
-      log.Info("License is valid")
-      return nil
-	}
-
-	err := backoff.Retry(check, backoff.NewExponentialBackOff())
-	if err != nil {
-    log.Error("Error in license check", "error", err)
-		os.Exit(1)
-	}
-
-	os.Exit(0)
+    sig := make(chan os.Signal)
+    signal.Notify(sig, os.Interrupt, os.Kill)
+    <-sig
+  }
+  os.Exit(0)
 }

--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rubenv/sql-migrate v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzFtS0=

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -35,9 +35,9 @@ func GetObjectReference() v1.ObjectReference {
     }
 }
 
-func GetEventSource() v1.EventSource {
+func GetEventSource(application string) v1.EventSource {
     return v1.EventSource{
-      Component: "replicated",
+      Component: application,
     }
 }
  
@@ -95,7 +95,7 @@ func PrepareLicenseEvent(client EventClient, application string, date time.Time)
     Message: message,
     InvolvedObject: podRef,
     FirstTimestamp: metav1.Time{Time: time.Now()},
-    Source: GetEventSource(),
+    Source: GetEventSource(application),
     Count: 1,
   }
   return event, nil

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -81,6 +81,10 @@ func PrepareLicenseEvent(client EventClient, valid bool, application string, dat
     ObjectMeta: metav1.ObjectMeta{
       GenerateName: fmt.Sprintf("%s.", strings.ToLower(application)),
       Namespace:   podRef.Namespace,
+      Annotations: map[string]string{
+        "application": application,
+        "expiration": date.Format(time.RFC3339),
+      },
     },
     Type:    eventType,
     Reason:  reason,

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -61,8 +61,11 @@ func PrepareLicenseEvent(client EventClient, valid bool, application string, dat
     return nil, err
   }
   if event != nil {
-    log.Debug("Event already exists, incrementing count", "previous", event.Count)
-    event.Count++
+    log.Debug("Event already exists")
+    if !valid {
+      log.Debug("Invalid event, incrementing count", "previous", event.Count)
+      event.Count++
+    }
     return event, nil
   }
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -17,8 +17,8 @@ import (
 )
 
 type EventClient interface {
-    GetLicenseEvent(valid bool, application string, date time.Time) (*v1.Event, error)
-    CreateLicenseEvent(valid bool, application string, date time.Time) error
+    GetLicenseEvent(application string, date time.Time) (*v1.Event, error)
+    CreateLicenseEvent(application string, date time.Time) error
 }
 
 type KubernetesEventClient struct {
@@ -54,8 +54,9 @@ func NewKubernetesEventClient() (*KubernetesEventClient, error) {
 }
 
 
-func PrepareLicenseEvent(client EventClient, valid bool, application string, date time.Time) (*v1.Event, error) {
-  event, err := client.GetLicenseEvent(valid, application, date)
+func PrepareLicenseEvent(client EventClient, application string, date time.Time) (*v1.Event, error) {
+  valid := date.After(time.Now())
+  event, err := client.GetLicenseEvent(application, date)
   if err != nil {
     log.Error("Error getting existing event", "error", err)
     return nil, err
@@ -63,7 +64,7 @@ func PrepareLicenseEvent(client EventClient, valid bool, application string, dat
   if event != nil {
     log.Debug("Event already exists")
     if !valid {
-      log.Debug("Invalid event, incrementing count", "previous", event.Count)
+      log.Debug("Expired event, incrementing count", "previous", event.Count)
       event.Count++
     }
     return event, nil
@@ -84,9 +85,9 @@ func PrepareLicenseEvent(client EventClient, valid bool, application string, dat
     ObjectMeta: metav1.ObjectMeta{
       GenerateName: fmt.Sprintf("%s.", strings.ToLower(application)),
       Namespace:   podRef.Namespace,
-      Annotations: map[string]string{
-        "application": application,
-        "expiration": date.Format(time.RFC3339),
+      Labels: map[string]string{
+        "replicated.com/application": application,
+        "replicated.com/expires-at": date.Format(time.RFC3339),
       },
     },
     Type:    eventType,
@@ -100,14 +101,11 @@ func PrepareLicenseEvent(client EventClient, valid bool, application string, dat
   return event, nil
 }
 
-func (c *KubernetesEventClient) GetLicenseEvent(valid bool, application string, date time.Time) (*v1.Event, error) {
+func (c *KubernetesEventClient) GetLicenseEvent(application string, date time.Time) (*v1.Event, error) {
     podRef := GetObjectReference()
-    reason := "Valid"
-    if !valid {
-        reason = "Expired"
-    }
     listOptions := metav1.ListOptions{
-        FieldSelector: fmt.Sprintf("involvedObject.uid=%s,reason=%s", podRef.UID, reason),
+        FieldSelector: getFieldSelector(date),
+        LabelSelector: getLabelSelector(application, date),
     }
     events, err := c.Clientset.CoreV1().Events(podRef.Namespace).List(context.TODO(), listOptions)
     if err != nil {
@@ -122,8 +120,8 @@ func (c *KubernetesEventClient) GetLicenseEvent(valid bool, application string, 
 }
 
 
-func (c *KubernetesEventClient) CreateLicenseEvent(valid bool, application string, date time.Time) error {
-    event, err := PrepareLicenseEvent(c, valid, application, date)
+func (c *KubernetesEventClient) CreateLicenseEvent(application string, date time.Time) error {
+    event, err := PrepareLicenseEvent(c, application, date)
     if err != nil {
       log.Error("Error preparing Kubernetes event", "error", err)
       return nil
@@ -137,4 +135,19 @@ func (c *KubernetesEventClient) CreateLicenseEvent(valid bool, application strin
 
     _, err = c.Clientset.CoreV1().Events(event.ObjectMeta.Namespace).Create(context.TODO(), event, metav1.CreateOptions{});
     return err
+}
+
+func getFieldSelector(date time.Time) string {
+  valid := date.After(time.Now())
+  reason := "Valid"
+  if !valid {
+      reason = "Expired"
+  }
+  log.Debug("Creating field selector", "involvedObject.name", os.Getenv("POD_NAME"), "involvedObject.namespace", os.Getenv("POD_NAMESPACE"), "reason", reason)
+  return fmt.Sprintf("involvedObject.name=%s,involvedObject.namespace=%s,reason=%s", os.Getenv("POD_NAME"), os.Getenv("POD_NAMESPACE"), reason)
+}
+
+func getLabelSelector(application string, date time.Time) string {
+  log.Debug("Creating label selector", "replicated.com/application", application, "replicated.com/expires-at", date)
+  return fmt.Sprintf("replicated.com/application=%s,replicated.com/expires-at=%s", application, date.Format(time.RFC3339))
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -87,7 +87,7 @@ func PrepareLicenseEvent(client EventClient, application string, date time.Time)
       Namespace:   podRef.Namespace,
       Labels: map[string]string{
         "replicated.com/application": application,
-        "replicated.com/expires-at": date.Format(time.RFC3339),
+        "replicated.com/expires-at": date.Format(time.DateOnly),
       },
     },
     Type:    eventType,
@@ -149,5 +149,5 @@ func getFieldSelector(date time.Time) string {
 
 func getLabelSelector(application string, date time.Time) string {
   log.Debug("Creating label selector", "replicated.com/application", application, "replicated.com/expires-at", date)
-  return fmt.Sprintf("replicated.com/application=%s,replicated.com/expires-at=%s", application, date.Format(time.RFC3339))
+  return fmt.Sprintf("replicated.com/application=%s,replicated.com/expires-at=%s", application, date.Format(time.DateOnly))
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -52,7 +52,6 @@ func TestSecondExpiredEvent(t *testing.T) {
     err = client.CreateLicenseEvent(application, past)
     event, err := client.GetLicenseEvent(application, past)
     assert.NoError(t, err)
-    assert.NoError(t, err)
     assert.Len(t, client.Events, 1)
     assert.Equal(t, int32(2), event.Count)
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -26,7 +26,7 @@ func TestExpiredEvent(t *testing.T) {
     assert.Equal(t, "Warning", event.Type)
     assert.Equal(t, "Expired", event.Reason)
     assert.Equal(t, application, event.ObjectMeta.Labels["replicated.com/application"])
-    assert.Equal(t, past.Format(time.RFC3339), event.ObjectMeta.Labels["replicated.com/expires-at"])
+    assert.Equal(t, past.Format(time.DateOnly), event.ObjectMeta.Labels["replicated.com/expires-at"])
 
     assert.Equal(t, fmt.Sprintf("%s license is not valid, expired %v", application, past), event.Message)
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -43,7 +43,7 @@ func TestExpiredEvent(t *testing.T) {
 
 func TestSecondExpiredEvent(t *testing.T) {
     client := NewMockEventClient() 
-    application := "Slackernews"
+    application := "slackernews-mackerel"
     past := time.Now().Add(-24 * time.Hour)
   
     err := client.CreateLicenseEvent(application, past)
@@ -59,7 +59,7 @@ func TestSecondExpiredEvent(t *testing.T) {
 
 func TestValidEvent(t *testing.T) {
     client := NewMockEventClient() 
-    application := "Slackernews"
+    application := "slackernews-mackerel"
     future := time.Now().Add(24 * time.Hour)
   
     err := client.CreateLicenseEvent(application, future)
@@ -73,7 +73,7 @@ func TestValidEvent(t *testing.T) {
 
 func TestSecondValidEvent(t *testing.T) {
     client := NewMockEventClient() 
-    application := "Slackernews"
+    application := "slackernews-mackerel"
     future := time.Now().Add(24 * time.Hour)
   
     err := client.CreateLicenseEvent(application, future)
@@ -91,7 +91,7 @@ func TestSecondValidEvent(t *testing.T) {
 
 func TestValidNewExpiration(t *testing.T) {
     client := NewMockEventClient() 
-    application := "Slackernews"
+    application := "slackernews-mackerel"
     future := time.Now().Add(24 * time.Hour)
     renewal := time.Now().Add(48 * time.Hour)
   

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -25,6 +25,8 @@ func TestFirstLicenseEvent(t *testing.T) {
     assert.Equal(t, podRef.Namespace, event.ObjectMeta.Namespace)
     assert.Equal(t, "Warning", event.Type)
     assert.Equal(t, "Expired", event.Reason)
+    assert.Equal(t, application, event.ObjectMeta.Annotations["application"])
+    assert.Equal(t, past.Format(time.RFC3339), event.ObjectMeta.Annotations["expiration"])
 
     assert.Equal(t, fmt.Sprintf("%s license is not valid, expired %v", application, past), event.Message)
 
@@ -59,6 +61,8 @@ func TestSecondLicenseEvent(t *testing.T) {
     assert.Equal(t, "Warning", event.Type)
     assert.Equal(t, "Expired", event.Reason)
     assert.Equal(t, int32(2), event.Count)
+    assert.Equal(t, application, event.ObjectMeta.Annotations["application"])
+    assert.Equal(t, past.Format(time.RFC3339), event.ObjectMeta.Annotations["expiration"])
 
     assert.Equal(t, fmt.Sprintf("%s license is not valid, expired %v", application, past), event.Message)
 
@@ -88,6 +92,8 @@ func TestFirstValidEvent(t *testing.T) {
     assert.Equal(t, podRef.Namespace, event.ObjectMeta.Namespace)
     assert.Equal(t, "Normal", event.Type)
     assert.Equal(t, "Valid", event.Reason)
+    assert.Equal(t, application, event.ObjectMeta.Annotations["application"])
+    assert.Equal(t, past.Format(time.RFC3339), event.ObjectMeta.Annotations["expiration"])
 
     assert.Equal(t, fmt.Sprintf("%s license is valid, expires %v", application, past), event.Message)
 
@@ -100,4 +106,3 @@ func TestFirstValidEvent(t *testing.T) {
     assert.NotEmpty(t, event.FirstTimestamp)
     assert.Equal(t, "replicated", event.Source.Component)
 }
-

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -12,7 +12,8 @@ import (
 func TestExpiredEvent(t *testing.T) {
     client := NewMockEventClient() 
     podRef := GetObjectReference()
-    application := "Slackernews"
+    application := "slackernews-mackerel"
+
     past := time.Now().Add(-24 * time.Hour)
   
     err := client.CreateLicenseEvent(application, past)
@@ -37,7 +38,7 @@ func TestExpiredEvent(t *testing.T) {
     assert.Equal(t, podRef.UID, event.InvolvedObject.UID)
 
     assert.NotEmpty(t, event.FirstTimestamp)
-    assert.Equal(t, "replicated", event.Source.Component)
+    assert.Equal(t, application, event.Source.Component)
 }
 
 func TestSecondExpiredEvent(t *testing.T) {

--- a/pkg/events/mock.go
+++ b/pkg/events/mock.go
@@ -20,7 +20,11 @@ func setupMockEnvironment() {
 }
 
 func generateEventKey(valid bool, application string, date time.Time) string {
-    return fmt.Sprintf("%t-%s-%s", valid, application, date.Format(time.RFC3339))
+    reason := "Valid"
+    if !valid {
+      reason = "Expired"
+    }
+    return fmt.Sprintf("%s-%s-%s", reason, application, date.Format(time.RFC3339))
 }
 
 func NewMockEventClient() *MockEventClient {

--- a/pkg/events/mock.go
+++ b/pkg/events/mock.go
@@ -5,6 +5,7 @@ import (
   "os"
   "time"
 
+  "github.com/charmbracelet/log"
   v1 "k8s.io/api/core/v1"
 )
 
@@ -19,37 +20,45 @@ func setupMockEnvironment() {
     os.Setenv("POD_UID", "0e8d56c7-6277-4a79-9847-bdcb3b4e3184")
 }
 
-func generateEventKey(valid bool, application string, date time.Time) string {
-    reason := "Valid"
-    if !valid {
-      reason = "Expired"
-    }
-    return fmt.Sprintf("%s-%s-%s", reason, application, date.Format(time.RFC3339))
+func generateEventKey(application string, date time.Time) string {
+    fieldSelector := getFieldSelector(date)
+    labelSelector := getLabelSelector(application, date)
+    log.Debug("Generated event key", "key", fmt.Sprintf("%s,%s", fieldSelector, labelSelector))
+    return fmt.Sprintf("%s,%s", fieldSelector, labelSelector)
 }
 
 func NewMockEventClient() *MockEventClient {
     setupMockEnvironment()
+    logLevel := os.Getenv("LOG_LEVEL")
+    if logLevel == "" {
+      logLevel = "fatal"
+    }
+    log.ParseLevel(logLevel)
     return &MockEventClient{
         Events: make(map[string]*v1.Event),
     }
 }
 
-func (c *MockEventClient) GetLicenseEvent(valid bool, application string, date time.Time) (*v1.Event, error) {
-    key := generateEventKey(valid, application, date)
+func (c *MockEventClient) GetLicenseEvent(application string, date time.Time) (*v1.Event, error) {
+    key := generateEventKey(application, date)
     event, ok := c.Events[key]
     if !ok { 
+      log.Debug("Event not found", "key", key)
       return nil, nil
     }
+    log.Debug("returning event", "event", event)
     return event, nil
 }
 
 
-func (c *MockEventClient) CreateLicenseEvent(valid bool, application string, date time.Time) error {
-    event, err := PrepareLicenseEvent(c, valid, application, date)
+func (c *MockEventClient) CreateLicenseEvent(application string, date time.Time) error {
+    event, err := PrepareLicenseEvent(c, application, date)
     if err != nil {
+      log.Error("Error preparing event", "error", err)
       return err
     }
-    key := generateEventKey(valid, application, date)
+    key := generateEventKey(application, date)
+    log.Debug("adding event to store", "key", key, "event", event)
     c.Events[key] = event
     return nil
 }


### PR DESCRIPTION
TL;DR
-----

Updates `enforce` to work as init or sidecar

Details
-------

Modifies the `enforce` CLI to allow running license enforcement as either an
init container or a sidecar. When running as a sidecar, the license is checked
periodcally after the first valid license check. Events are emitted as before,
with an additional event emitted whenever a valid license has a change in
expiration date.
