### PR TITLE
Clarifies limitation on circumvention

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ of the Replicated license.
 
 1. This code is provided _AS IS_ and is not supported by Replicated.
 
-2. Your customer can circumvent this by editing Kubernetes manifests. I don't
-   consider that too much of a limitation because you still have legal
-   remedies. It'll even help your case that the worked to circumvent your
-   enforcement.
+2. Your customer can circumvent the init container or sidecar implementations
+   by editing Kubernetes manifests. I don't consider that too much of a
+   limitation because you still have legal remedies. It'll even help your case
+   that the worked to circumvent your enforcement. The best way to avoid this
+   is to use the `enforce` package in your code.


### PR DESCRIPTION
TL;DR
-----

Updstes the README to make the limtation on init/sidecar use clearer

Details
-------

Adds some additional context to the second limitation on the code. It's
only a limitation for using `enforce` in a sidecar or init container,
not when `enforce` is used in the vendor's code.
